### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/1](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/1)

The best way to fix this issue is to define a `permissions` block that grants only `contents: read` at the root level of the workflow file. This establishes a minimal permission set (`contents: read`) for all jobs, as recommended by GitHub, and adheres to the principle of least privilege. You should add this block as a top-level key anywhere after the `name` and before `jobs` (commonly after `on`, but before `jobs`). No existing permissions are required for this workflow's current steps; if future jobs require more, you can override the block at the job level. No other modifications or imports are needed—this is a YAML configuration fix only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
