### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"math"
 )
 
 // Instruction represents a parsed ARM instruction
@@ -541,6 +542,9 @@ func parseNumber(s string) (uint32, error) {
 
 	result := uint32(value)
 	if negative {
+		if result > uint32(math.MaxInt32) {
+			return 0, fmt.Errorf("negative value %d is out of range for int32", result)
+		}
 		result = uint32(-int32(result))
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/2](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/2)

To fix the problem, we must ensure that any value parsed as an unsigned 32-bit number that is then negated and converted to int32 (then cast back to uint32) is well bounded. The safest approach is to check that the value is no greater than `math.MaxInt32` before the conversion when negative, as it must fit into the signed range; otherwise, return an error.  
  
Recommended changes:  
- Import "math" for `math.MaxInt32`.  
- Before line 544 (`result = uint32(-int32(result))`), add a check:  
  - If `result > math.MaxInt32`, return an error indicating out-of-bounds negative value.  
- Alternatively, instead of applying the negative after converting to uint32, negate the parsed value as an int32 if it fits.

Edits required:  
- In file `parser/parser.go`, inside function `parseNumber`, after the value has been parsed to `uint32`, check for bounds before converting to int32 if negative.  
- Add import of "math" to the import block if missing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
