### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/debugger/commands.go
+++ b/debugger/commands.go
@@ -2,6 +2,7 @@ package debugger
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -295,7 +296,11 @@ func (d *Debugger) cmdPrint(args []string) error {
 		return err
 	}
 
-	d.Printf("$%d = 0x%08X (%d)\n", d.Evaluator.GetValueNumber(), result, int32(result))
+	if result > uint32(math.MaxInt32) {
+		d.Printf("$%d = 0x%08X (out of int32 range: %d)\n", d.Evaluator.GetValueNumber(), result, result)
+	} else {
+		d.Printf("$%d = 0x%08X (%d)\n", d.Evaluator.GetValueNumber(), result, int32(result))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/3](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/3)

To fix the problem, we should ensure that before converting `result` (a `uint32`) into `int32` for printing, we check that it does not exceed `math.MaxInt32` (and is not negative, though parsing logic only allows positive values). If it is out of bounds, we should either avoid the conversion, print an error, or display another representation (e.g., "out of int32 range").  
Specifically, in `debugger/commands.go`, line 298, we should add a check (e.g., `if result > math.MaxInt32`) before casting `result` to `int32`. If it's out of bounds, display a suitable message (`"out of int32 range"` or just print the `uint32`).  
To implement, we need to import `"math"` at the top of `debugger/commands.go`, and update cmdPrint accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
