### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/encoder/branch.go
+++ b/encoder/branch.go
@@ -3,6 +3,7 @@ package encoder
 import (
 	"fmt"
 	"strings"
+	"math"
 
 	"github.com/lookbusy1344/arm-emulator/parser"
 )
@@ -40,6 +41,10 @@ func (e *Encoder) encodeBranch(inst *parser.Instruction, cond uint32) (uint32, e
 	// Calculate offset: (target - PC - 8) / 4
 	// PC is current instruction address + 8 (ARM pipeline)
 	pc := e.currentAddr + 8
+	// Ensure targetAddr is safely convertible to int32
+	if targetAddr > math.MaxInt32 {
+		return 0, fmt.Errorf("branch target address out of int32 range: 0x%X", targetAddr)
+	}
 	offset := int32(targetAddr) - int32(pc)
 
 	// Check if offset is word-aligned


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/4](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/4)

To address this issue, we need to ensure that `targetAddr`, which may be an arbitrary `uint32`, is within the valid range for an `int32` before converting it. The conversion should only occur after confirming that the value is between `math.MinInt32` and `math.MaxInt32` (in practice, since `targetAddr` is always non-negative, we're only concerned about `math.MaxInt32`). This can be done with a simple if-statement before the unsafe conversion. If the condition fails, we should return an error indicating the branch target is out of range. The appropriate line to add this check is immediately before line 43 in `encoder/branch.go`, and you will need to import `math` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
