### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -2,6 +2,7 @@ package encoder
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -190,6 +191,10 @@ func (e *Encoder) parseImmediate(imm string) (uint32, error) {
 
 	result := uint32(value)
 	if negative {
+		// Bounds check before casting to int32 and negating
+		if result > uint32(math.MaxInt32)+1 {
+			return 0, fmt.Errorf("immediate value out of valid signed 32-bit range: %s", imm)
+		}
 		result = uint32(-int32(result))
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/5](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/5)

To correctly handle the conversion between types and avoid unexpected results, we need to ensure that, before converting to `int32` for negation, the value does not exceed the maximum value representable by a signed 32-bit integer (`math.MaxInt32`, i.e., 2147483647). If it does, the function should return an error or a default value. Similarly, when performing negation, if the value is greater than `math.MaxInt32 + 1` (the minimum representable signed int32 is -2147483648), we need to ensure the negative does not overflow. 

**Steps:**
- Add `import "math"` at the top if it's not imported.
- Before performing `result = uint32(-int32(result))`, check that `result <= math.MaxInt32 + 1` (or use explicit limits).
- Return an error (or default) if out-of-range.
- This change is confined to the `parseImmediate` method in `encoder/encoder.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
