### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -233,10 +233,10 @@ func (e *Encoder) parseImmediate(imm string) (uint32, error) {
 	result := uint32(value)
 	if negative {
 		// Bounds check before casting to int32 and negating
-		if result > uint32(math.MaxInt32)+1 {
+		if result < 1 || result > uint32(math.MaxInt32)+1 {
 			return 0, fmt.Errorf("immediate value out of valid signed 32-bit range: %s", imm)
 		}
-		// Safe: value checked to be in valid range for negation
+		// Safe: value checked to be in valid range for signed negation
 		result = uint32(-int32(result)) // #nosec G115 -- bounds checked above
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/6](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/6)

To fix the issue, we will strengthen the bounds checking around the conversion from `uint32` to `int32` and its negation. Specifically:

- **Where:** In `func (e *Encoder) parseImmediate` in encoder/encoder.go, lines 236-240.
- **What:** Before converting and negating, ensure that the value is at least 1 and at most `math.MaxInt32 + 1` (i.e., between 1 and 2147483648), since negating 2147483648 in int32 yields the minimum `int32`, which is valid, and negating anything larger would overflow.
- **How:** Change the bounds check from `result > uint32(math.MaxInt32)+1` to a more explicit range: `if result < 1 || result > uint32(math.MaxInt32)+1` (reject zero and values above the valid range).
- **Imports:** The code already imports `"math"`, so no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
