### PR TITLE
Add SHA256 checksum generation to release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,6 +59,26 @@ jobs:
           fi
           echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
 
+      - name: Generate SHA256 checksum
+        id: checksum
+        shell: bash
+        run: |
+          ARTIFACT_NAME="${{ steps.artifact.outputs.artifact_name }}"
+          CHECKSUM_FILE="${ARTIFACT_NAME}.sha256"
+
+          # Generate SHA256 checksum
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            certutil -hashfile "$ARTIFACT_NAME" SHA256 | findstr /V ":" | findstr /V "CertUtil" > "$CHECKSUM_FILE"
+          else
+            shasum -a 256 "$ARTIFACT_NAME" > "$CHECKSUM_FILE"
+          fi
+
+          echo "checksum_file=$CHECKSUM_FILE" >> $GITHUB_OUTPUT
+
+          # Display checksum for verification
+          echo "Generated checksum:"
+          cat "$CHECKSUM_FILE"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -66,10 +86,48 @@ jobs:
           path: ${{ steps.artifact.outputs.artifact_name }}
           retention-days: 30
 
+      - name: Upload checksum
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.checksum.outputs.checksum_file }}
+          path: ${{ steps.checksum.outputs.checksum_file }}
+          retention-days: 30
+
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ steps.artifact.outputs.artifact_name }}
+          files: |
+            ${{ steps.artifact.outputs.artifact_name }}
+            ${{ steps.checksum.outputs.checksum_file }}
+          draft: false
+          prerelease: false
+
+  create-checksums-file:
+    name: Create SHA256SUMS file
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download all checksum artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*.sha256"
+          path: checksums
+          merge-multiple: true
+
+      - name: Create combined SHA256SUMS file
+        run: |
+          cd checksums
+          # Combine all checksum files into SHA256SUMS
+          cat *.sha256 > SHA256SUMS
+
+          echo "Combined SHA256SUMS file:"
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: checksums/SHA256SUMS
           draft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -399,9 +399,31 @@ git push origin v1.0.0
 ```
 
 This triggers the `Build Release` workflow which:
-- Builds optimized binaries for **linux-amd64**, **darwin-arm64**, and **windows-amd64**
-- Creates a GitHub Release with pre-built binaries for each platform
+- Builds optimized binaries for **linux-amd64**, **darwin-arm64**, **windows-amd64**, and **windows-arm64**
+- Generates SHA256 checksums for each binary
+- Creates a GitHub Release with pre-built binaries, individual checksums, and a combined SHA256SUMS file
 - Users can download platform-specific binaries directly from the [Releases](https://github.com/lookbusy1344/arm_emulator/releases) page
+
+**Verifying downloads:**
+
+To verify the integrity of a downloaded binary, use the SHA256 checksums provided in the release:
+
+```bash
+# On Linux/macOS - verify using the combined SHA256SUMS file
+sha256sum -c SHA256SUMS --ignore-missing
+
+# On Linux/macOS - verify a specific binary
+sha256sum arm-emulator-linux-amd64
+# Compare the output with the checksum in the .sha256 file
+
+# On Windows (PowerShell)
+Get-FileHash arm-emulator-windows-amd64.exe -Algorithm SHA256
+# Compare the output with the checksum in the .sha256 file
+```
+
+Each release includes:
+- Individual `.sha256` files for each binary (e.g., `arm-emulator-linux-amd64.sha256`)
+- A combined `SHA256SUMS` file containing all checksums for easy verification
 
 ## Project Structure
 


### PR DESCRIPTION
- Generate SHA256 checksums for each platform binary
- Upload individual .sha256 files with each release artifact
- Create combined SHA256SUMS file with all checksums
- Add documentation on how to verify downloads
- Support cross-platform checksum generation (Linux/macOS/Windows)

Users can now verify the integrity of downloaded binaries using the provided checksums, enhancing security and trust in the release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)