### PR TITLE
docs: condense PROGRESS.md from 2,912 to 267 lines

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,6 +16,10 @@ This is a complete ARM2 emulator written in Go with ARMv3 extensions, featuring 
 
 ## Recent Highlights (October 2025)
 
+For detailed historical information, see:
+- **[docs/CHANGELOG.md](docs/CHANGELOG.md)** - Comprehensive changelog with all October 2025 updates
+- **[docs/SECURITY.md](docs/SECURITY.md)** - Detailed security analyses and critical bug fixes
+
 ### Security Hardening (Oct 22-23)
 - ✅ Comprehensive buffer overflow protection across all syscalls
 - ✅ Memory segment wraparound attack protection verified
@@ -24,6 +28,8 @@ This is a complete ARM2 emulator written in Go with ARMv3 extensions, featuring 
 - ✅ File descriptor table size limit (1024)
 - ✅ Address validation and wraparound protection
 - ✅ 52 new security tests added, all passing
+
+**See [docs/SECURITY.md](docs/SECURITY.md) for detailed security analysis and threat model.**
 
 ### TUI Enhancements (Oct 19)
 - ✅ Memory write highlighting (green) in TUI debugger


### PR DESCRIPTION
Cleaned up PROGRESS.md by:
- Removing excessive detail from 38 recent update entries
- Converting detailed phase checklists to concise summaries
- Keeping essential information: recent highlights, phase summaries, current status, test results
- Maintaining all important metrics and notes

Result: 90% reduction in length while preserving key information

🤖 Generated with [Claude Code](https://claude.com/claude-code)