### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, e2e]


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/arm_emulator/security/code-scanning/9](https://github.com/lookbusy1344/arm_emulator/security/code-scanning/9)

The best way to fix this problem is to add a `permissions` block with the minimum necessary privileges for the workflow. In this case, the required permissions are likely `contents: read`, as the jobs check out code and upload artifacts but do not seem to need write access to repository contents, issues, or pull requests. The permissions block can be added at the root level, just below the workflow `name:` or above the `jobs:` key, ensuring that all jobs in the workflow inherit this least-privilege setting (unless otherwise specified). No changes to methods, imports, or step logic are needed—just insert a properly indented block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
